### PR TITLE
Possible fixes in sparsity & eqivariance

### DIFF
--- a/measurements/properties/equivariance/equivariance.py
+++ b/measurements/properties/equivariance/equivariance.py
@@ -42,7 +42,7 @@ class Equivariance(Measurement):
 
     def test_step(self, batch, batch_idx):
         x, labels = batch
-        z = self.model.forward_features(x).cpu()
+        z = self.model.forward_features(x)
         z_t = None
 
         for magnitude_idx in range(10):
@@ -50,12 +50,16 @@ class Equivariance(Measurement):
                 self.transformation_name, magnitude_idx
             )
             x_i_t = transform(x)
-            z_i_t = self.model.forward_features(x_i_t).cpu()
+            z_i_t = self.model.forward_features(x_i_t)
             if z_t is None:
                 z_t = z_i_t.unsqueeze(-1)
             else:
                 z_t = torch.cat([z_t, z_i_t.unsqueeze(-1)], dim=-1)
 
+        if self.z.device != z.device:
+            self.z = self.z.to(z.device)
+        if self.z_t.device != z_t.device:
+            self.z_t = self.z_t.to(z_t.device)
         self.z = torch.cat([self.z, z])
         self.z_t = torch.cat([self.z_t, z_t])
         return None

--- a/measurements/properties/sparsity/sparsity.py
+++ b/measurements/properties/sparsity/sparsity.py
@@ -32,7 +32,9 @@ class Sparsity(Measurement):
     def test_step(self, batch, batch_idx):
         x, _ = batch
         # if we make forward features all layers, we could play with the layer we compute metrics on
-        z = self.model.forward_features(x).cpu()
+        z = self.model.forward_features(x)
+        if self.z.device != z.device:
+            self.z = self.z.to(z.device)
         self.z = torch.cat([self.z, z])
         return None
 


### PR DESCRIPTION
When running measurements `equivariance_imagenet_dummy` and `sparsity_imagenet_dummy`, I had to do a few small changes to the code, not sure if these are my local / not correctly merged issues, but here are a few potential fixes:

- making sure the device is always CPU for both sparsity and equivariance / invariance computation (or should we put all tensors on GPU instead?)
- fixing argument name for `Sparsity` as in config: `dataset_names` -> `datamodule_names`