### PR TITLE
Multi-label evaluation for calibration

### DIFF
--- a/measurements/properties/calibration/calibration.py
+++ b/measurements/properties/calibration/calibration.py
@@ -11,7 +11,8 @@ import numpy as np
 class NLL(Measurement):
     """Negative Log-Likelihood"""
 
-    def __init__(self,
+    def __init__(
+        self,
         datamodule_names: List[str],
         model: ClassifierModule,
         experiment_config: DictConfig,
@@ -58,7 +59,8 @@ class NLL(Measurement):
 class ECE(Measurement):
     """Expected Calibration Error"""
 
-    def __init__(self,
+    def __init__(
+        self,
         datamodule_names: List[str],
         model: ClassifierModule,
         experiment_config: DictConfig,
@@ -78,7 +80,10 @@ class ECE(Measurement):
                 y = [[int(x) for x in y[i].split(',')] for i in range(len(y))]
             y_hat = self.model(x)
             self.save_predictions(
-                {"prediction": F.softmax(y_hat, dim=-1).cpu().tolist(), "label": y}
+                {
+                    "prediction": F.softmax(y_hat, dim=-1).cpu().tolist(),
+                    "label": y
+                }
             )
             return None
 
@@ -86,7 +91,7 @@ class ECE(Measurement):
 
     @staticmethod
     def measure_ece(preds, targets, n_bins=15):
-        """ Adapted from https://github.com/SamsungLabs/pytorch-ensembles/blob/master/metrics.py
+        """Adapted from https://github.com/SamsungLabs/pytorch-ensembles/blob/master/metrics.py
         Args:
             preds: numpy array of shape (num samples, num classes)
             targets: numpy array of shape (num samples,)
@@ -102,7 +107,7 @@ class ECE(Measurement):
             for i in range(len(targets)):
                 accuracies[i] = predictions[i] in targets[i]
         else:
-            accuracies = (predictions == targets)
+            accuracies = predictions == targets
 
         ece = 0.0
         for bin_lower, bin_upper in zip(bin_lowers, bin_uppers):
@@ -130,7 +135,7 @@ class ECE(Measurement):
             ece_val = self.measure_ece(
                 np.array(self.model.predictions["prediction"].tolist()),
                 np.array(self.model.predictions["label"].tolist()),
-                n_bins=self.n_bins
+                n_bins=self.n_bins,
             )
             results_dict[f"{datamodule_name}_calibration_ece"] = ece_val
 


### PR DESCRIPTION
Evaluating ECE and NLL with multi-label annotations:
- in ECE the main change is that we consider the predictions correct if they fall within the plausible set of labels,
- for NLL we take the single target per image corresponding to the max softmax probability out of the plausible classes to compute the loss.

I tested the code with the kaggle version of DollarStreet from anther branch. 

There are a few points for discussion:
- In which format should the multi label annotations be and what data types should different functions (like `test_step`) expect? E.g. if the data loader yields y's which are strings with comma-separated indexes, then at some point we should process that string into the list of indexes -- where should that better be?
- After deciding on the point above, I will delete TODO's and we can figure out the cleanest way to test whether we are in a single-label or multi-label case.
- I am not sure how to create a unit test for `make_test_step` function.